### PR TITLE
Revert "Saca key de addons de app.json"

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,3 +1,4 @@
 {
+  "addons": ["heroku-postgresql:hobby-dev"],
   "stack": "container"
 }


### PR DESCRIPTION
Parece que sí era necesario, porque el addon creeeo que era del docker, no de heroku. No entendí bien igual, quizá está mal heroku nomás.